### PR TITLE
feat(spotify-token): saving spotify token authorization

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Spotilist",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "Playlist maker based in spotify api",
   "main": "index.js",
   "repository": "git@github.com:mxdsxn/spotify-playlist.git",

--- a/src/common/token/index.ts
+++ b/src/common/token/index.ts
@@ -43,7 +43,7 @@ const verifyToken = (req: Request, res: Response, next: NextFunction) => {
     }
 
     if (decoded) {
-      req.body.userId = decoded.useCreateIndex
+      req.body.userId = decoded.id
 
       return next()
     }

--- a/src/use-cases/spotify-connection/index.ts
+++ b/src/use-cases/spotify-connection/index.ts
@@ -1,9 +1,11 @@
 import express from 'express'
 import { appAuthorizationRoute } from './app-authorization'
 import { userAuthenticationRoute } from './user-authentication'
+import { verifyToken } from '@token'
 
 const spotifyConnectionRoute = express.Router()
 
+spotifyConnectionRoute.use(verifyToken)
 spotifyConnectionRoute.use(
   '/spotify_connection',
   appAuthorizationRoute,

--- a/src/use-cases/spotify-connection/user-authentication/route.ts
+++ b/src/use-cases/spotify-connection/user-authentication/route.ts
@@ -1,4 +1,5 @@
 import express from 'express'
+import User from 'src/schemas/user'
 import spotifyService from './service'
 
 const userAuthenticationRoute = express.Router()
@@ -7,6 +8,14 @@ userAuthenticationRoute.get('/authentication-token', async (req, res) => {
   try {
     const codeAuthorization = req.query.code as string
     const result = await spotifyService.getAppAuthenticationUrl(codeAuthorization)
+
+
+    const { access_token } = result
+    const { userId } = req.body
+
+    await User.findByIdAndUpdate(userId, {
+      spotifyToken: access_token
+    })
 
     return res.json(result)
 


### PR DESCRIPTION
Com essa alteração, quando o usuário concede acesso a sua conta do spotify à aplicação, o token de autenticação gerado pelo web-api-spotify é armazenado e associado ao usuario